### PR TITLE
Use correct config file on ubuntu 16.04.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,6 @@ class locales::params {
 
       case $::operatingsystem {
         'Ubuntu': {
-          $config_file = '/var/lib/locales/supported.d/local'
           $package     = 'locales'
           case $::lsbdistcodename {
             'hardy': {
@@ -32,6 +31,14 @@ class locales::params {
             }
             default: {
               $update_locale_pkg = 'libc-bin'
+            }
+          }
+          case $::operatingsystemrelease {
+            '16.04': {
+              $config_file = '/etc/locale.gen'
+            }
+            default: {
+              $config_file = '/var/lib/locales/supported.d/local'
             }
           }
         }


### PR DESCRIPTION
From ubuntu 15.10 to ubuntu 16.04, the locale config file location
changed.  It used to live at /var/lib/locales/supported.d/local but
moved to /etc/locale.gen .

This code should manifestly be modified (soon) to understand that we
really want "version 16.04 or later".  That, oddly, exceeds my
puppet-fu.  Suggestions most welcome.